### PR TITLE
Refactor large components

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Progress } from "@/components/ui/progress"
+import { Sidebar } from "@/components/layout/sidebar"
 import {
   Upload,
   FileText,
@@ -230,84 +231,18 @@ export default function LightshipweightGWPTool() {
 
   return (
     <div className="min-h-screen bg-slate-50">
-      {/* Sidebar */}
-      <div
-        className={`fixed inset-y-0 left-0 z-50 w-64 bg-white border-r border-slate-200 transform transition-transform duration-200 ease-in-out ${
-          sidebarOpen ? "translate-x-0" : "-translate-x-full"
-        }`}
-      >
-        {/* Sidebar Header */}
-        <div className="flex items-center justify-between h-16 px-6 border-b border-slate-200">
-          <div className="flex items-center">
-            <Image src="/pelagos-core-logo.svg" alt="Pelagos Core" width={140} height={28} className="h-7 w-auto" />
-          </div>
-          <Button variant="ghost" size="sm" onClick={() => setSidebarOpen(false)} className="lg:hidden">
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
-
-        {/* Main Navigation */}
-        <nav className="flex-1 px-4 py-6">
-          <div className="space-y-2">
-            {mainSections.map((section) => {
-              const Icon = section.icon
-              return (
-                <button
-                  key={section.id}
-                  onClick={() => setActiveView(section.id)}
-                  className={`w-full flex items-center gap-3 px-3 py-3 text-sm font-medium rounded-lg transition-colors ${
-                    activeView === section.id
-                      ? "bg-blue-50 text-blue-700 border border-blue-200"
-                      : "text-slate-600 hover:text-slate-900 hover:bg-slate-50"
-                  }`}
-                >
-                  <Icon className="h-5 w-5" />
-                  <div className="flex-1 text-left">
-                    <div className="font-medium">{section.label}</div>
-                    <div className="text-xs text-slate-500">{section.description}</div>
-                  </div>
-                  {section.badge && (
-                    <Badge variant={activeView === section.id ? "default" : "secondary"} className="text-xs">
-                      {section.badge}
-                    </Badge>
-                  )}
-                </button>
-              )
-            })}
-          </div>
-
-          {/* Analysis Progress - Solo se c'è un'analisi in corso */}
-          {(currentStep > 1 || uploadedFiles.length > 0) && (
-            <div className="mt-8 pt-6 border-t border-slate-200">
-              <div className="mb-4">
-                <h3 className="text-sm font-medium text-slate-700 mb-2">Current Analysis</h3>
-                <div className="text-xs text-slate-500 mb-3">{getCurrentStepInfo().description}</div>
-                <div className="flex items-center justify-between text-sm mb-2">
-                  <span className="font-medium text-slate-600">Progress</span>
-                  <span className="text-slate-500">{Math.round(getProgressPercentage())}%</span>
-                </div>
-                <Progress value={getProgressPercentage()} className="h-2" />
-              </div>
-
-              {/* Reset Button */}
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  if (confirm("Reset analysis? All progress will be lost.")) {
-                    resetTool()
-                  }
-                }}
-                className="w-full flex items-center gap-2 text-slate-600"
-              >
-                <RotateCcw className="h-4 w-4" />
-                Reset Analysis
-              </Button>
-            </div>
-          )}
-        </nav>
-      </div>
-
+      <Sidebar
+        open={sidebarOpen}
+        onClose={() => setSidebarOpen(false)}
+        sections={mainSections}
+        activeView={activeView}
+        setActiveView={setActiveView}
+        currentStep={currentStep}
+        uploadedFiles={uploadedFiles}
+        getProgressPercentage={getProgressPercentage}
+        getCurrentStepInfo={getCurrentStepInfo}
+        resetTool={resetTool}
+      />
       {/* Main Content */}
       <div className={`transition-all duration-200 ${sidebarOpen ? "lg:ml-64" : ""}`}>
         {/* Top Header */}

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import Image from "next/image"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Progress } from "@/components/ui/progress"
+import { X, RotateCcw } from "lucide-react"
+import type { LucideIcon } from "lucide-react"
+
+interface Section {
+  id: string
+  label: string
+  icon: LucideIcon
+  description: string
+  badge?: string
+}
+
+interface SidebarProps {
+  open: boolean
+  onClose: () => void
+  sections: Section[]
+  activeView: string
+  setActiveView: (id: string) => void
+  currentStep: number
+  uploadedFiles: File[]
+  getProgressPercentage: () => number
+  getCurrentStepInfo: () => { description: string }
+  resetTool: () => void
+}
+
+export function Sidebar({
+  open,
+  onClose,
+  sections,
+  activeView,
+  setActiveView,
+  currentStep,
+  uploadedFiles,
+  getProgressPercentage,
+  getCurrentStepInfo,
+  resetTool,
+}: SidebarProps) {
+  return (
+    <div
+      className={`fixed inset-y-0 left-0 z-50 w-64 bg-white border-r border-slate-200 transform transition-transform duration-200 ease-in-out ${open ? "translate-x-0" : "-translate-x-full"}`}
+    >
+      <div className="flex items-center justify-between h-16 px-6 border-b border-slate-200">
+        <div className="flex items-center">
+          <Image src="/pelagos-core-logo.svg" alt="Pelagos Core" width={140} height={28} className="h-7 w-auto" />
+        </div>
+        <Button variant="ghost" size="sm" onClick={onClose} className="lg:hidden">
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+      <nav className="flex-1 px-4 py-6">
+        <div className="space-y-2">
+          {sections.map((section) => {
+            const Icon = section.icon
+            return (
+              <button
+                key={section.id}
+                onClick={() => setActiveView(section.id)}
+                className={`w-full flex items-center gap-3 px-3 py-3 text-sm font-medium rounded-lg transition-colors ${activeView === section.id ? "bg-blue-50 text-blue-700 border border-blue-200" : "text-slate-600 hover:text-slate-900 hover:bg-slate-50"}`}
+              >
+                <Icon className="h-5 w-5" />
+                <div className="flex-1 text-left">
+                  <div className="font-medium">{section.label}</div>
+                  <div className="text-xs text-slate-500">{section.description}</div>
+                </div>
+                {section.badge && (
+                  <Badge variant={activeView === section.id ? "default" : "secondary"} className="text-xs">
+                    {section.badge}
+                  </Badge>
+                )}
+              </button>
+            )
+          })}
+        </div>
+        {(currentStep > 1 || uploadedFiles.length > 0) && (
+          <div className="mt-8 pt-6 border-t border-slate-200">
+            <div className="mb-4">
+              <h3 className="text-sm font-medium text-slate-700 mb-2">Current Analysis</h3>
+              <div className="text-xs text-slate-500 mb-3">{getCurrentStepInfo().description}</div>
+              <div className="flex items-center justify-between text-sm mb-2">
+                <span className="font-medium text-slate-600">Progress</span>
+                <span className="text-slate-500">{Math.round(getProgressPercentage())}%</span>
+              </div>
+              <Progress value={getProgressPercentage()} className="h-2" />
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                if (confirm("Reset analysis? All progress will be lost.")) {
+                  resetTool()
+                }
+              }}
+              className="w-full flex items-center gap-2 text-slate-600"
+            >
+              <RotateCcw className="h-4 w-4" />
+              Reset Analysis
+            </Button>
+          </div>
+        )}
+      </nav>
+    </div>
+  )
+}
+

--- a/components/materials-manager.tsx
+++ b/components/materials-manager.tsx
@@ -11,15 +11,6 @@ import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Badge } from "@/components/ui/badge"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Plus, Edit, Trash2, Search, Download, Upload, Save, CheckCircle, AlertTriangle } from "lucide-react"
@@ -27,6 +18,10 @@ import { MaterialsDatabase, type Material } from "@/lib/materials-database-supab
 import { validateMaterial, parseAliases, formatAliases } from "@/lib/utils/material-utils"
 import { MATERIAL_CATEGORIES } from "@/lib/constants"
 import { notificationService } from "@/lib/services/notification-service"
+
+import { AddMaterialDialog } from "./materials-manager/add-material-dialog"
+import { EditMaterialDialog } from "./materials-manager/edit-material-dialog"
+import { StatsView } from "./materials-manager/stats-view"
 
 export default function MaterialsManager() {
   const [materialsDb] = useState(() => new MaterialsDatabase())
@@ -320,121 +315,13 @@ export default function MaterialsManager() {
                     ))}
                   </SelectContent>
                 </Select>
-                <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
-                  <DialogTrigger asChild>
-                    <Button>
-                      <Plus className="h-4 w-4 mr-2" />
-                      Add Material
-                    </Button>
-                  </DialogTrigger>
-                  <DialogContent className="max-w-2xl">
-                    <DialogHeader>
-                      <DialogTitle>Add New Material</DialogTitle>
-                      <DialogDescription>
-                        Enter information for the new material to add to the database
-                      </DialogDescription>
-                    </DialogHeader>
-                    <div className="grid gap-4 py-4">
-                      <div className="grid grid-cols-2 gap-4">
-                        <div>
-                          <Label htmlFor="name">Material Name *</Label>
-                          <Input
-                            id="name"
-                            value={newMaterial.name}
-                            onChange={(e) => setNewMaterial({ ...newMaterial, name: e.target.value })}
-                            placeholder="e.g. Stainless steel"
-                          />
-                        </div>
-                        <div>
-                          <Label htmlFor="category">Category *</Label>
-                          <Select
-                            value={newMaterial.category}
-                            onValueChange={(value) => setNewMaterial({ ...newMaterial, category: value })}
-                          >
-                            <SelectTrigger>
-                              <SelectValue placeholder="Select category" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {MATERIAL_CATEGORIES.map((category) => (
-                                <SelectItem key={category} value={category}>
-                                  {category}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        </div>
-                      </div>
-                      <div>
-                        <Label htmlFor="aliases">Aliases (comma separated)</Label>
-                        <Input
-                          id="aliases"
-                          value={formatAliases(newMaterial.aliases || [])}
-                          onChange={(e) => setNewMaterial({ ...newMaterial, aliases: parseAliases(e.target.value) })}
-                          placeholder="e.g. inox, stainless steel, aisi 316"
-                        />
-                      </div>
-                      <div className="grid grid-cols-3 gap-4">
-                        <div>
-                          <Label htmlFor="gwpFactor">GWP Factor (kg CO₂eq/kg) *</Label>
-                          <Input
-                            id="gwpFactor"
-                            type="number"
-                            step="0.1"
-                            value={newMaterial.gwpFactor}
-                            onChange={(e) =>
-                              setNewMaterial({ ...newMaterial, gwpFactor: Number.parseFloat(e.target.value) })
-                            }
-                          />
-                        </div>
-                        <div>
-                          <Label htmlFor="unit">Unit</Label>
-                          <Select
-                            value={newMaterial.unit}
-                            onValueChange={(value) => setNewMaterial({ ...newMaterial, unit: value })}
-                          >
-                            <SelectTrigger>
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="kg">kg</SelectItem>
-                              <SelectItem value="m³">m³</SelectItem>
-                              <SelectItem value="m²">m²</SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </div>
-                        <div>
-                          <Label htmlFor="density">Density (kg/m³)</Label>
-                          <Input
-                            id="density"
-                            type="number"
-                            value={newMaterial.density}
-                            onChange={(e) =>
-                              setNewMaterial({ ...newMaterial, density: Number.parseFloat(e.target.value) })
-                            }
-                          />
-                        </div>
-                      </div>
-                      <div>
-                        <Label htmlFor="description">Description</Label>
-                        <Textarea
-                          id="description"
-                          value={newMaterial.description}
-                          onChange={(e) => setNewMaterial({ ...newMaterial, description: e.target.value })}
-                          placeholder="Material description and characteristics"
-                        />
-                      </div>
-                    </div>
-                    <DialogFooter>
-                      <Button variant="outline" onClick={() => setIsAddDialogOpen(false)}>
-                        Cancel
-                      </Button>
-                      <Button onClick={handleAddMaterial}>
-                        <Save className="h-4 w-4 mr-2" />
-                        Save Material
-                      </Button>
-                    </DialogFooter>
-                  </DialogContent>
-                </Dialog>
+                <AddMaterialDialog
+                  isOpen={isAddDialogOpen}
+                  onOpenChange={setIsAddDialogOpen}
+                  newMaterial={newMaterial}
+                  onMaterialChange={setNewMaterial}
+                  onSave={handleAddMaterial}
+                />
               </div>
 
               {/* Materials table */}
@@ -532,178 +419,20 @@ export default function MaterialsManager() {
               </div>
             </TabsContent>
 
-            <TabsContent value="stats" className="space-y-4">
-              <div className="grid md:grid-cols-4 gap-4">
-                <Card>
-                  <CardContent className="p-4 text-center">
-                    <p className="text-2xl font-bold text-blue-600">{materials.length}</p>
-                    <p className="text-sm text-gray-600">Total Materials</p>
-                  </CardContent>
-                </Card>
-                <Card>
-                  <CardContent className="p-4 text-center">
-                    <p className="text-2xl font-bold text-green-600">{categories.length}</p>
-                    <p className="text-sm text-gray-600">Categories</p>
-                  </CardContent>
-                </Card>
-                <Card>
-                  <CardContent className="p-4 text-center">
-                    <p className="text-2xl font-bold text-purple-600">
-                      {materials.reduce((sum, m) => sum + m.aliases.length, 0)}
-                    </p>
-                    <p className="text-sm text-gray-600">Total Aliases</p>
-                  </CardContent>
-                </Card>
-                <Card>
-                  <CardContent className="p-4 text-center">
-                    <p className="text-2xl font-bold text-orange-600">
-                      {materials.length > 0
-                        ? (materials.reduce((sum, m) => sum + m.gwpFactor, 0) / materials.length).toFixed(1)
-                        : 0}
-                    </p>
-                    <p className="text-sm text-gray-600">Average GWP</p>
-                  </CardContent>
-                </Card>
-              </div>
-
-              <Card>
-                <CardHeader>
-                  <CardTitle>Distribution by Category</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="space-y-3">
-                    {categories.map((category) => {
-                      const count = materials.filter((m) => m.category === category).length
-                      const percentage = materials.length > 0 ? (count / materials.length) * 100 : 0
-                      return (
-                        <div key={category}>
-                          <div className="flex justify-between mb-1">
-                            <span className="text-sm font-medium">{category}</span>
-                            <span className="text-sm text-gray-600">
-                              {count} ({percentage.toFixed(1)}%)
-                            </span>
-                          </div>
-                          <div className="w-full bg-gray-200 rounded-full h-2">
-                            <div className="bg-blue-600 h-2 rounded-full" style={{ width: `${percentage}%` }} />
-                          </div>
-                        </div>
-                      )
-                    })}
-                  </div>
-                </CardContent>
-              </Card>
+            <TabsContent value="stats">
+              <StatsView materials={materials} />
             </TabsContent>
           </Tabs>
         </CardContent>
       </Card>
 
-      {/* Edit dialog */}
-      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
-        <DialogContent className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>Edit Material</DialogTitle>
-            <DialogDescription>Edit the selected material information</DialogDescription>
-          </DialogHeader>
-          {editingMaterial && (
-            <div className="grid gap-4 py-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <Label htmlFor="edit-name">Material Name</Label>
-                  <Input
-                    id="edit-name"
-                    value={editingMaterial.name}
-                    onChange={(e) => setEditingMaterial({ ...editingMaterial, name: e.target.value })}
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="edit-category">Category</Label>
-                  <Select
-                    value={editingMaterial.category}
-                    onValueChange={(value) => setEditingMaterial({ ...editingMaterial, category: value })}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {MATERIAL_CATEGORIES.map((category) => (
-                        <SelectItem key={category} value={category}>
-                          {category}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-              <div>
-                <Label htmlFor="edit-aliases">Aliases</Label>
-                <Input
-                  id="edit-aliases"
-                  value={formatAliases(editingMaterial.aliases)}
-                  onChange={(e) => setEditingMaterial({ ...editingMaterial, aliases: parseAliases(e.target.value) })}
-                />
-              </div>
-              <div className="grid grid-cols-3 gap-4">
-                <div>
-                  <Label htmlFor="edit-gwpFactor">GWP Factor</Label>
-                  <Input
-                    id="edit-gwpFactor"
-                    type="number"
-                    step="0.1"
-                    value={editingMaterial.gwpFactor}
-                    onChange={(e) =>
-                      setEditingMaterial({ ...editingMaterial, gwpFactor: Number.parseFloat(e.target.value) })
-                    }
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="edit-unit">Unit</Label>
-                  <Select
-                    value={editingMaterial.unit}
-                    onValueChange={(value) => setEditingMaterial({ ...editingMaterial, unit: value })}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="kg">kg</SelectItem>
-                      <SelectItem value="m³">m³</SelectItem>
-                      <SelectItem value="m²">m²</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div>
-                  <Label htmlFor="edit-density">Density</Label>
-                  <Input
-                    id="edit-density"
-                    type="number"
-                    value={editingMaterial.density || ""}
-                    onChange={(e) =>
-                      setEditingMaterial({ ...editingMaterial, density: Number.parseFloat(e.target.value) })
-                    }
-                  />
-                </div>
-              </div>
-              <div>
-                <Label htmlFor="edit-description">Description</Label>
-                <Textarea
-                  id="edit-description"
-                  value={editingMaterial.description || ""}
-                  onChange={(e) => setEditingMaterial({ ...editingMaterial, description: e.target.value })}
-                />
-              </div>
-            </div>
-          )}
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setIsEditDialogOpen(false)}>
-              Cancel
-            </Button>
-            <Button onClick={handleEditMaterial}>
-              <Save className="h-4 w-4 mr-2" />
-              Save Changes
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <EditMaterialDialog
+        isOpen={isEditDialogOpen}
+        onOpenChange={setIsEditDialogOpen}
+        editingMaterial={editingMaterial}
+        onMaterialChange={(mat) => setEditingMaterial(mat)}
+        onSave={handleEditMaterial}
+      />
     </div>
   )
 }

--- a/components/materials-manager/add-material-dialog.tsx
+++ b/components/materials-manager/add-material-dialog.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
+import { Save, Plus } from "lucide-react"
+import type { Material } from "@/lib/materials-database-supabase"
+import { MATERIAL_CATEGORIES } from "@/lib/constants"
+import { parseAliases, formatAliases } from "@/lib/utils/material-utils"
+
+interface AddMaterialDialogProps {
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+  newMaterial: Partial<Material>
+  onMaterialChange: (material: Partial<Material>) => void
+  onSave: () => void
+}
+
+export function AddMaterialDialog({
+  isOpen,
+  onOpenChange,
+  newMaterial,
+  onMaterialChange,
+  onSave,
+}: AddMaterialDialogProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Add Material
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Add New Material</DialogTitle>
+          <DialogDescription>Enter information for the new material to add to the database</DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="name">Material Name *</Label>
+              <Input
+                id="name"
+                value={newMaterial.name}
+                onChange={(e) => onMaterialChange({ ...newMaterial, name: e.target.value })}
+                placeholder="e.g. Stainless steel"
+              />
+            </div>
+            <div>
+              <Label htmlFor="category">Category *</Label>
+              <Select value={newMaterial.category} onValueChange={(value) => onMaterialChange({ ...newMaterial, category: value })}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select category" />
+                </SelectTrigger>
+                <SelectContent>
+                  {MATERIAL_CATEGORIES.map((category) => (
+                    <SelectItem key={category} value={category}>
+                      {category}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="aliases">Aliases (comma separated)</Label>
+            <Input
+              id="aliases"
+              value={formatAliases(newMaterial.aliases || [])}
+              onChange={(e) => onMaterialChange({ ...newMaterial, aliases: parseAliases(e.target.value) })}
+              placeholder="e.g. inox, stainless steel, aisi 316"
+            />
+          </div>
+          <div className="grid grid-cols-3 gap-4">
+            <div>
+              <Label htmlFor="gwpFactor">GWP Factor (kg CO₂eq/kg) *</Label>
+              <Input
+                id="gwpFactor"
+                type="number"
+                step="0.1"
+                value={newMaterial.gwpFactor}
+                onChange={(e) => onMaterialChange({ ...newMaterial, gwpFactor: Number.parseFloat(e.target.value) })}
+              />
+            </div>
+            <div>
+              <Label htmlFor="unit">Unit</Label>
+              <Select value={newMaterial.unit} onValueChange={(value) => onMaterialChange({ ...newMaterial, unit: value })}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="kg">kg</SelectItem>
+                  <SelectItem value="m³">m³</SelectItem>
+                  <SelectItem value="m²">m²</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor="density">Density (kg/m³)</Label>
+              <Input
+                id="density"
+                type="number"
+                value={newMaterial.density}
+                onChange={(e) => onMaterialChange({ ...newMaterial, density: Number.parseFloat(e.target.value) })}
+              />
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="description">Description</Label>
+            <Textarea
+              id="description"
+              value={newMaterial.description}
+              onChange={(e) => onMaterialChange({ ...newMaterial, description: e.target.value })}
+              placeholder="Material description and characteristics"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={onSave}>
+            <Save className="h-4 w-4 mr-2" />
+            Save Material
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+

--- a/components/materials-manager/edit-material-dialog.tsx
+++ b/components/materials-manager/edit-material-dialog.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Save } from "lucide-react"
+import type { Material } from "@/lib/materials-database-supabase"
+import { MATERIAL_CATEGORIES } from "@/lib/constants"
+import { parseAliases, formatAliases } from "@/lib/utils/material-utils"
+
+interface EditMaterialDialogProps {
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+  editingMaterial: Material | null
+  onMaterialChange: (material: Material) => void
+  onSave: () => void
+}
+
+export function EditMaterialDialog({
+  isOpen,
+  onOpenChange,
+  editingMaterial,
+  onMaterialChange,
+  onSave,
+}: EditMaterialDialogProps) {
+  if (!editingMaterial) return null
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Edit Material</DialogTitle>
+          <DialogDescription>Edit the selected material information</DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="edit-name">Material Name</Label>
+              <Input id="edit-name" value={editingMaterial.name} onChange={(e) => onMaterialChange({ ...editingMaterial, name: e.target.value })} />
+            </div>
+            <div>
+              <Label htmlFor="edit-category">Category</Label>
+              <Select value={editingMaterial.category} onValueChange={(value) => onMaterialChange({ ...editingMaterial, category: value })}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {MATERIAL_CATEGORIES.map((category) => (
+                    <SelectItem key={category} value={category}>
+                      {category}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="edit-aliases">Aliases</Label>
+            <Input
+              id="edit-aliases"
+              value={formatAliases(editingMaterial.aliases)}
+              onChange={(e) => onMaterialChange({ ...editingMaterial, aliases: parseAliases(e.target.value) })}
+            />
+          </div>
+          <div className="grid grid-cols-3 gap-4">
+            <div>
+              <Label htmlFor="edit-gwpFactor">GWP Factor</Label>
+              <Input
+                id="edit-gwpFactor"
+                type="number"
+                step="0.1"
+                value={editingMaterial.gwpFactor}
+                onChange={(e) => onMaterialChange({ ...editingMaterial, gwpFactor: Number.parseFloat(e.target.value) })}
+              />
+            </div>
+            <div>
+              <Label htmlFor="edit-unit">Unit</Label>
+              <Select value={editingMaterial.unit} onValueChange={(value) => onMaterialChange({ ...editingMaterial, unit: value })}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="kg">kg</SelectItem>
+                  <SelectItem value="m³">m³</SelectItem>
+                  <SelectItem value="m²">m²</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor="edit-density">Density</Label>
+              <Input
+                id="edit-density"
+                type="number"
+                value={editingMaterial.density || ""}
+                onChange={(e) => onMaterialChange({ ...editingMaterial, density: Number.parseFloat(e.target.value) })}
+              />
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="edit-description">Description</Label>
+            <Textarea id="edit-description" value={editingMaterial.description || ""} onChange={(e) => onMaterialChange({ ...editingMaterial, description: e.target.value })} />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={onSave}>
+            <Save className="h-4 w-4 mr-2" />
+            Save Changes
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+

--- a/components/materials-manager/stats-view.tsx
+++ b/components/materials-manager/stats-view.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+interface StatsViewProps {
+  materials: { category: string; aliases: string[]; gwpFactor: number }[]
+}
+
+export function StatsView({ materials }: StatsViewProps) {
+  const categories = Array.from(new Set(materials.map((m) => m.category)))
+  return (
+    <div className="space-y-4">
+      <div className="grid md:grid-cols-4 gap-4">
+        <Card>
+          <CardContent className="p-4 text-center">
+            <p className="text-2xl font-bold text-blue-600">{materials.length}</p>
+            <p className="text-sm text-gray-600">Total Materials</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4 text-center">
+            <p className="text-2xl font-bold text-green-600">{categories.length}</p>
+            <p className="text-sm text-gray-600">Categories</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4 text-center">
+            <p className="text-2xl font-bold text-purple-600">{materials.reduce((sum, m) => sum + m.aliases.length, 0)}</p>
+            <p className="text-sm text-gray-600">Total Aliases</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4 text-center">
+            <p className="text-2xl font-bold text-orange-600">
+              {materials.length > 0 ? (materials.reduce((sum, m) => sum + m.gwpFactor, 0) / materials.length).toFixed(1) : 0}
+            </p>
+            <p className="text-sm text-gray-600">Average GWP</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Distribution by Category</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {categories.map((category) => {
+              const count = materials.filter((m) => m.category === category).length
+              const percentage = materials.length > 0 ? (count / materials.length) * 100 : 0
+              return (
+                <div key={category}>
+                  <div className="flex justify-between mb-1">
+                    <span className="text-sm font-medium">{category}</span>
+                    <span className="text-sm text-gray-600">
+                      {count} ({percentage.toFixed(1)}%)
+                    </span>
+                  </div>
+                  <div className="w-full bg-gray-200 rounded-full h-2">
+                    <div className="bg-blue-600 h-2 rounded-full" style={{ width: `${percentage}%` }} />
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+

--- a/components/parsing-validation.tsx
+++ b/components/parsing-validation.tsx
@@ -18,6 +18,7 @@ import { MaterialStats } from "./parsing-validation/material-stats"
 import { CategoryCard } from "./parsing-validation/category-card"
 import { UncategorizedCard } from "./parsing-validation/uncategorized-card"
 import { AddMaterialDialog } from "./parsing-validation/add-material-dialog"
+import { MaterialsList } from "./parsing-validation/materials-list"
 
 interface ValidationMaterial extends ParsedMaterial {
   isValidated: boolean
@@ -375,34 +376,22 @@ export default function ParsingValidation({ parsedDocuments, onValidationComplet
             </Select>
           </div>
 
-          {/* Materiali organizzati per macrogruppo */}
-          <div className="space-y-4">
-            {Object.entries(categories).map(([categoryId, categoryData]) => (
-              <CategoryCard
-                key={categoryId}
-                categoryId={categoryId}
-                categoryData={categoryData}
-                isExpanded={expandedCategories.has(categoryId)}
-                validationMaterials={validationMaterials}
-                availableMaterials={availableMaterials}
-                isLoadingMaterials={isLoadingMaterials}
-                onToggleCategory={toggleCategory}
-                onMaterialSelection={handleMaterialSelection}
-                onQuantityChange={handleQuantityChange}
-                onValidationToggle={handleValidationToggle}
-                onRemoveMaterial={handleRemoveMaterial}
-                onAddMaterial={handleAddMaterial}
-              />
-            ))}
-
-            {/* Materiali non categorizzati */}
-            <UncategorizedCard
-              uncategorized={uncategorized}
-              allCategories={allCategories}
-              validationMaterials={validationMaterials}
-              onCategorySelection={handleCategorySelection}
-            />
-          </div>
+          <MaterialsList
+            categories={categories}
+            uncategorized={uncategorized}
+            allCategories={allCategories}
+            expandedCategories={expandedCategories}
+            validationMaterials={validationMaterials}
+            availableMaterials={availableMaterials}
+            isLoadingMaterials={isLoadingMaterials}
+            onToggleCategory={toggleCategory}
+            onMaterialSelection={handleMaterialSelection}
+            onQuantityChange={handleQuantityChange}
+            onValidationToggle={handleValidationToggle}
+            onRemoveMaterial={handleRemoveMaterial}
+            onAddMaterial={handleAddMaterial}
+            onCategorySelection={handleCategorySelection}
+          />
 
           {/* Pulsante di completamento */}
           <div className="flex justify-between items-center mt-6">

--- a/components/parsing-validation/materials-list.tsx
+++ b/components/parsing-validation/materials-list.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import { CategoryCard } from "./category-card"
+import { UncategorizedCard } from "./uncategorized-card"
+import type { ValidationMaterial } from "../parsing-validation"
+import type { Material } from "@/lib/materials-database-supabase"
+import type { PCRCategory } from "@/lib/pcr-categories"
+
+interface MaterialsByCategory {
+  [categoryId: string]: { category: PCRCategory; materials: ValidationMaterial[] }
+}
+
+interface MaterialsListProps {
+  categories: MaterialsByCategory
+  uncategorized: ValidationMaterial[]
+  allCategories: PCRCategory[]
+  expandedCategories: Set<string>
+  validationMaterials: ValidationMaterial[]
+  availableMaterials: Material[]
+  isLoadingMaterials: boolean
+  onToggleCategory: (id: string) => void
+  onMaterialSelection: (index: number, material: Material) => void
+  onQuantityChange: (index: number, quantity: number) => void
+  onValidationToggle: (index: number) => void
+  onRemoveMaterial: (index: number) => void
+  onAddMaterial: (index: number) => void
+  onCategorySelection: (index: number, category: PCRCategory) => void
+}
+
+export function MaterialsList({
+  categories,
+  uncategorized,
+  allCategories,
+  expandedCategories,
+  validationMaterials,
+  availableMaterials,
+  isLoadingMaterials,
+  onToggleCategory,
+  onMaterialSelection,
+  onQuantityChange,
+  onValidationToggle,
+  onRemoveMaterial,
+  onAddMaterial,
+  onCategorySelection,
+}: MaterialsListProps) {
+  return (
+    <div className="space-y-4">
+      {Object.entries(categories).map(([categoryId, categoryData]) => (
+        <CategoryCard
+          key={categoryId}
+          categoryId={categoryId}
+          categoryData={categoryData}
+          isExpanded={expandedCategories.has(categoryId)}
+          validationMaterials={validationMaterials}
+          availableMaterials={availableMaterials}
+          isLoadingMaterials={isLoadingMaterials}
+          onToggleCategory={onToggleCategory}
+          onMaterialSelection={onMaterialSelection}
+          onQuantityChange={onQuantityChange}
+          onValidationToggle={onValidationToggle}
+          onRemoveMaterial={onRemoveMaterial}
+          onAddMaterial={onAddMaterial}
+        />
+      ))}
+
+      <UncategorizedCard
+        uncategorized={uncategorized}
+        allCategories={allCategories}
+        validationMaterials={validationMaterials}
+        onCategorySelection={onCategorySelection}
+      />
+    </div>
+  )
+}
+

--- a/components/results-display.tsx
+++ b/components/results-display.tsx
@@ -16,13 +16,15 @@ import {
   AlertTriangle,
   HelpCircle,
   Package,
-  Target,
   Save,
 } from "lucide-react"
 import type { GWPCalculation } from "@/lib/gwp-calculator"
 import { projectsService } from "@/lib/services/projects-service"
 import { useAppState } from "@/lib/services/app-state"
 import { notificationService } from "@/lib/services/notification-service"
+
+import { MacroGroupChart } from "./results-display/macro-group-chart"
+import { BreakdownChart } from "./results-display/breakdown-chart"
 
 interface ResultsDisplayProps {
   gwpResults: GWPCalculation
@@ -353,132 +355,12 @@ export default function ResultsDisplay({ gwpResults, onReset }: ResultsDisplayPr
         </TabsContent>
 
         <TabsContent value="macrogroups" className="space-y-6">
-          {/* Macro-group impact visualization */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Package className="h-5 w-5" />
-                PCR Macro-Group Impact Analysis
-              </CardTitle>
-              <CardDescription>
-                Visual representation of how each PCR macro-group contributes to the total GWP
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-6">
-                {/* Visual pie chart representation */}
-                <div className="flex justify-center">
-                  <div className="relative w-64 h-64">
-                    <svg viewBox="0 0 200 200" className="w-full h-full">
-                      {macroGroupAnalysis.map((group, index) => {
-                        const startAngle = macroGroupAnalysis
-                          .slice(0, index)
-                          .reduce((sum, g) => sum + (g.percentage / 100) * 360, 0)
-                        const endAngle = startAngle + (group.percentage / 100) * 360
-                        const largeArcFlag = group.percentage > 50 ? 1 : 0
-
-                        const x1 = 100 + 80 * Math.cos((startAngle * Math.PI) / 180)
-                        const y1 = 100 + 80 * Math.sin((startAngle * Math.PI) / 180)
-                        const x2 = 100 + 80 * Math.cos((endAngle * Math.PI) / 180)
-                        const y2 = 100 + 80 * Math.sin((endAngle * Math.PI) / 180)
-
-                        const pathData = [
-                          `M 100 100`,
-                          `L ${x1} ${y1}`,
-                          `A 80 80 0 ${largeArcFlag} 1 ${x2} ${y2}`,
-                          `Z`,
-                        ].join(" ")
-
-                        const colors = ["#3B82F6", "#10B981", "#F59E0B", "#EF4444", "#8B5CF6", "#6366F1", "#EC4899"]
-
-                        return (
-                          <path
-                            key={group.id}
-                            d={pathData}
-                            fill={colors[index % colors.length]}
-                            stroke="white"
-                            strokeWidth="2"
-                            className="hover:opacity-80 transition-opacity"
-                          />
-                        )
-                      })}
-                    </svg>
-                  </div>
-                </div>
-
-                {/* Legend and details */}
-                <div className="grid md:grid-cols-2 gap-4">
-                  {macroGroupAnalysis.map((group, index) => (
-                    <Card key={group.id} className="relative overflow-hidden">
-                      <div className={`absolute left-0 top-0 bottom-0 w-1 ${getColorForIndex(index)}`} />
-                      <CardContent className="p-4 pl-6">
-                        <div className="flex items-center justify-between mb-2">
-                          <div>
-                            <div className="flex items-center gap-2">
-                              <span className="font-mono text-sm bg-gray-100 px-2 py-1 rounded">{group.code}</span>
-                              <span className="font-medium text-sm">{group.name}</span>
-                            </div>
-                          </div>
-                          <div className="text-right">
-                            <div className={`text-lg font-bold ${getTextColorForIndex(index)}`}>
-                              {formatNumber(group.totalGWP / 1000)}t
-                            </div>
-                            <div className="text-xs text-gray-500">{group.percentage.toFixed(1)}% of total</div>
-                          </div>
-                        </div>
-
-                        {/* Progress bar */}
-                        <div className="w-full bg-gray-200 rounded-full h-2 mb-2">
-                          <div
-                            className={`h-2 rounded-full ${getColorForIndex(index)}`}
-                            style={{ width: `${Math.min(100, group.percentage)}%` }}
-                          />
-                        </div>
-
-                        <div className="text-xs text-gray-600">
-                          {group.materials.length} materials • Avg:{" "}
-                          {formatNumber(group.totalGWP / group.materials.length / 1000)}t per material
-                        </div>
-                      </CardContent>
-                    </Card>
-                  ))}
-                </div>
-
-                {/* Impact ranking */}
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <Target className="h-5 w-5" />
-                      Impact Ranking
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="space-y-3">
-                      {macroGroupAnalysis.map((group, index) => (
-                        <div key={group.id} className="flex items-center gap-4">
-                          <div className="flex items-center justify-center w-8 h-8 rounded-full bg-gray-100 text-sm font-bold">
-                            {index + 1}
-                          </div>
-                          <div className="flex-1">
-                            <div className="flex items-center gap-2">
-                              <span className="font-mono text-xs bg-gray-100 px-2 py-1 rounded">{group.code}</span>
-                              <span className="font-medium">{group.name}</span>
-                            </div>
-                          </div>
-                          <div className="text-right">
-                            <div className={`font-bold ${getTextColorForIndex(index)}`}>
-                              {formatNumber(group.totalGWP / 1000)}t CO₂eq
-                            </div>
-                            <div className="text-xs text-gray-500">{group.percentage.toFixed(1)}%</div>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </CardContent>
-                </Card>
-              </div>
-            </CardContent>
-          </Card>
+          <MacroGroupChart
+            data={macroGroupAnalysis}
+            formatNumber={formatNumber}
+            getColorForIndex={getColorForIndex}
+            getTextColorForIndex={getTextColorForIndex}
+          />
         </TabsContent>
 
         <TabsContent value="materials" className="space-y-6">
@@ -530,69 +412,7 @@ export default function ResultsDisplay({ gwpResults, onReset }: ResultsDisplayPr
         </TabsContent>
 
         <TabsContent value="breakdown" className="space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Emissions Breakdown by Phase</CardTitle>
-              <CardDescription>Distribution of emissions across different lifecycle phases</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-6">
-                <div className="grid md:grid-cols-3 gap-4">
-                  <div className="text-center p-4 border rounded-lg">
-                    <p className="text-2xl font-bold text-blue-600">
-                      {formatNumber(gwpResults.breakdown.production / 1000)}
-                    </p>
-                    <p className="text-sm text-gray-600">Material Production</p>
-                    <p className="text-xs text-gray-500">75% of total</p>
-                  </div>
-                  <div className="text-center p-4 border rounded-lg">
-                    <p className="text-2xl font-bold text-orange-600">
-                      {formatNumber(gwpResults.breakdown.transport / 1000)}
-                    </p>
-                    <p className="text-sm text-gray-600">Transportation</p>
-                    <p className="text-xs text-gray-500">15% of total</p>
-                  </div>
-                  <div className="text-center p-4 border rounded-lg">
-                    <p className="text-2xl font-bold text-purple-600">
-                      {formatNumber(gwpResults.breakdown.processing / 1000)}
-                    </p>
-                    <p className="text-sm text-gray-600">Processing</p>
-                    <p className="text-xs text-gray-500">10% of total</p>
-                  </div>
-                </div>
-
-                <div className="space-y-3">
-                  <div>
-                    <div className="flex justify-between mb-1">
-                      <span className="text-sm font-medium">Material Production</span>
-                      <span className="text-sm text-gray-600">75%</span>
-                    </div>
-                    <div className="w-full bg-gray-200 rounded-full h-3">
-                      <div className="bg-blue-600 h-3 rounded-full" style={{ width: "75%" }} />
-                    </div>
-                  </div>
-                  <div>
-                    <div className="flex justify-between mb-1">
-                      <span className="text-sm font-medium">Transportation</span>
-                      <span className="text-sm text-gray-600">15%</span>
-                    </div>
-                    <div className="w-full bg-gray-200 rounded-full h-3">
-                      <div className="bg-orange-600 h-3 rounded-full" style={{ width: "15%" }} />
-                    </div>
-                  </div>
-                  <div>
-                    <div className="flex justify-between mb-1">
-                      <span className="text-sm font-medium">Processing</span>
-                      <span className="text-sm text-gray-600">10%</span>
-                    </div>
-                    <div className="w-full bg-gray-200 rounded-full h-3">
-                      <div className="bg-purple-600 h-3 rounded-full" style={{ width: "10%" }} />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+          <BreakdownChart data={gwpResults.breakdown} formatNumber={formatNumber} />
         </TabsContent>
 
         <TabsContent value="recommendations" className="space-y-6">

--- a/components/results-display/breakdown-chart.tsx
+++ b/components/results-display/breakdown-chart.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+interface BreakdownData {
+  production: number
+  transport: number
+  processing: number
+}
+
+interface BreakdownChartProps {
+  data: BreakdownData
+  formatNumber: (n: number) => string
+}
+
+export function BreakdownChart({ data, formatNumber }: BreakdownChartProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Emissions Breakdown by Phase</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-6">
+          <div className="grid md:grid-cols-3 gap-4">
+            <div className="text-center p-4 border rounded-lg">
+              <p className="text-2xl font-bold text-blue-600">{formatNumber(data.production / 1000)}</p>
+              <p className="text-sm text-gray-600">Material Production</p>
+              <p className="text-xs text-gray-500">75% of total</p>
+            </div>
+            <div className="text-center p-4 border rounded-lg">
+              <p className="text-2xl font-bold text-orange-600">{formatNumber(data.transport / 1000)}</p>
+              <p className="text-sm text-gray-600">Transportation</p>
+              <p className="text-xs text-gray-500">15% of total</p>
+            </div>
+            <div className="text-center p-4 border rounded-lg">
+              <p className="text-2xl font-bold text-purple-600">{formatNumber(data.processing / 1000)}</p>
+              <p className="text-sm text-gray-600">Processing</p>
+              <p className="text-xs text-gray-500">10% of total</p>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <div>
+              <div className="flex justify-between mb-1">
+                <span className="text-sm font-medium">Material Production</span>
+                <span className="text-sm text-gray-600">75%</span>
+              </div>
+              <div className="w-full bg-gray-200 rounded-full h-3">
+                <div className="bg-blue-600 h-3 rounded-full" style={{ width: "75%" }} />
+              </div>
+            </div>
+            <div>
+              <div className="flex justify-between mb-1">
+                <span className="text-sm font-medium">Transportation</span>
+                <span className="text-sm text-gray-600">15%</span>
+              </div>
+              <div className="w-full bg-gray-200 rounded-full h-3">
+                <div className="bg-orange-600 h-3 rounded-full" style={{ width: "15%" }} />
+              </div>
+            </div>
+            <div>
+              <div className="flex justify-between mb-1">
+                <span className="text-sm font-medium">Processing</span>
+                <span className="text-sm text-gray-600">10%</span>
+              </div>
+              <div className="w-full bg-gray-200 rounded-full h-3">
+                <div className="bg-purple-600 h-3 rounded-full" style={{ width: "10%" }} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/components/results-display/macro-group-chart.tsx
+++ b/components/results-display/macro-group-chart.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Package, Target } from "lucide-react"
+
+interface MacroGroup {
+  id: string
+  name: string
+  code: string
+  totalGWP: number
+  materials: any[]
+  percentage: number
+}
+
+interface MacroGroupChartProps {
+  data: MacroGroup[]
+  formatNumber: (n: number) => string
+  getColorForIndex: (i: number) => string
+  getTextColorForIndex: (i: number) => string
+}
+
+export function MacroGroupChart({ data, formatNumber, getColorForIndex, getTextColorForIndex }: MacroGroupChartProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Package className="h-5 w-5" />
+          PCR Macro-Group Impact Analysis
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-6">
+          <div className="flex justify-center">
+            <div className="relative w-64 h-64">
+              <svg viewBox="0 0 200 200" className="w-full h-full">
+                {data.map((group, index) => {
+                  const startAngle = data.slice(0, index).reduce((sum, g) => sum + (g.percentage / 100) * 360, 0)
+                  const endAngle = startAngle + (group.percentage / 100) * 360
+                  const largeArcFlag = group.percentage > 50 ? 1 : 0
+
+                  const x1 = 100 + 80 * Math.cos((startAngle * Math.PI) / 180)
+                  const y1 = 100 + 80 * Math.sin((startAngle * Math.PI) / 180)
+                  const x2 = 100 + 80 * Math.cos((endAngle * Math.PI) / 180)
+                  const y2 = 100 + 80 * Math.sin((endAngle * Math.PI) / 180)
+
+                  const pathData = [`M 100 100`, `L ${x1} ${y1}`, `A 80 80 0 ${largeArcFlag} 1 ${x2} ${y2}`, `Z`].join(" ")
+                  const colors = ["#3B82F6", "#10B981", "#F59E0B", "#EF4444", "#8B5CF6", "#6366F1", "#EC4899"]
+                  return <path key={group.id} d={pathData} fill={colors[index % colors.length]} stroke="white" strokeWidth="2" className="hover:opacity-80 transition-opacity" />
+                })}
+              </svg>
+            </div>
+          </div>
+
+          <div className="grid md:grid-cols-2 gap-4">
+            {data.map((group, index) => (
+              <Card key={group.id} className="relative overflow-hidden">
+                <div className={`absolute left-0 top-0 bottom-0 w-1 ${getColorForIndex(index)}`} />
+                <CardContent className="p-4 pl-6">
+                  <div className="flex items-center justify-between mb-2">
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-sm bg-gray-100 px-2 py-1 rounded">{group.code}</span>
+                      <span className="font-medium text-sm">{group.name}</span>
+                    </div>
+                    <div className="text-right">
+                      <div className={`text-lg font-bold ${getTextColorForIndex(index)}`}>{formatNumber(group.totalGWP / 1000)}t</div>
+                      <div className="text-xs text-gray-500">{group.percentage.toFixed(1)}% of total</div>
+                    </div>
+                  </div>
+                  <div className="w-full bg-gray-200 rounded-full h-2 mb-2">
+                    <div className={`h-2 rounded-full ${getColorForIndex(index)}`} style={{ width: `${Math.min(100, group.percentage)}%` }} />
+                  </div>
+                  <div className="text-xs text-gray-600">
+                    {group.materials.length} materials • Avg: {formatNumber(group.totalGWP / group.materials.length / 1000)}t per material
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Target className="h-5 w-5" />
+                Impact Ranking
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                {data.map((group, index) => (
+                  <div key={group.id} className="flex items-center gap-4">
+                    <div className="flex items-center justify-center w-8 h-8 rounded-full bg-gray-100 text-sm font-bold">{index + 1}</div>
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono text-xs bg-gray-100 px-2 py-1 rounded">{group.code}</span>
+                        <span className="font-medium">{group.name}</span>
+                      </div>
+                    </div>
+                    <div className="text-right">
+                      <div className={`font-bold ${getTextColorForIndex(index)}`}>{formatNumber(group.totalGWP / 1000)}t CO₂eq</div>
+                      <div className="text-xs text-gray-500">{group.percentage.toFixed(1)}%</div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+


### PR DESCRIPTION
## Summary
- split out add and edit dialogs in MaterialsManager
- move materials stats to StatsView
- extract macro group and breakdown charts
- modularize materials list handling
- create Sidebar component and integrate into layout

## Testing
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_684aa7a9cbd0832abbbb65a2a55b5eeb