### PR TITLE
Add admin lookup management to EcoDesign section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CS Yacht Assessment Tool
 
-*Automatically synced with your [v0.dev](https://v0.dev) deployments*
+_Automatically synced with your [v0.dev](https://v0.dev) deployments_
 
 [![Deployed on Vercel](https://img.shields.io/badge/Deployed%20on-Vercel-black?style=for-the-badge&logo=vercel)](https://vercel.com/ludoludvigs-projects/v0-creare-tool-online)
 [![Built with v0](https://img.shields.io/badge/Built%20with-v0.dev-black?style=for-the-badge)](https://v0.dev/chat/projects/Qq4e542IC1f)
@@ -8,6 +8,13 @@
 ## Overview
 
 This repository will stay in sync with your deployed chats on [v0.dev](https://v0.dev).
+
+## EcoDesign Guidelines
+
+The `EcoDesign` section is available from the sidebar and lets users browse sustainability guidelines.
+Normal users can filter guidelines by life-cycle phase and target group.
+Administrators can add new guidelines and manage lookup tables (target groups and implementation groups).
+The Supabase database schema for this feature is stored in `sql/ecodesign_schema.sql`.
 Any changes you make to your deployed app will be automatically pushed to this repository from [v0.dev](https://v0.dev).
 
 ## Deployment

--- a/sql/ecodesign_schema.sql
+++ b/sql/ecodesign_schema.sql
@@ -1,0 +1,96 @@
+-- SQL schema for EcoDesign Guidelines
+-- This script creates all tables and types required for managing guidelines
+
+-- 1. Enable schema and extension
+create schema if not exists lcd_guidelines;
+set search_path to lcd_guidelines, public;
+create extension if not exists "pgcrypto";
+
+-- 2. ENUMS
+create type priority_enum as enum ('Low', 'Medium', 'High');
+create type life_cycle_phase_enum as enum (
+  'Upstream', 'Design', 'Production', 'Operation', 'Downstream', 'End-of-Life'
+);
+
+-- 3. LOOKUP TABLES
+create table target_groups (id uuid primary key default gen_random_uuid(), code text unique, label text);
+create table implementation_groups (id uuid primary key default gen_random_uuid(), code text unique, label text);
+create table hull_types (id uuid primary key default gen_random_uuid(), code text unique, label text);
+create table propulsion_types (id uuid primary key default gen_random_uuid(), code text unique, label text);
+create table yacht_size_classes (id uuid primary key default gen_random_uuid(), code text unique, label text);
+create table operational_profiles (id uuid primary key default gen_random_uuid(), code text unique, label text);
+create table technology_readiness_levels (id uuid primary key default gen_random_uuid(), code text unique, label text);
+
+-- 4. STRATEGY STRUCTURE
+create table strategies (
+  id uuid primary key default gen_random_uuid(),
+  name text not null unique
+);
+
+create table substrategies (
+  id uuid primary key default gen_random_uuid(),
+  strategy_id uuid not null references strategies(id) on delete cascade,
+  name text not null,
+  unique (strategy_id, name)
+);
+
+-- 5. GUIDELINES
+create table guidelines (
+  id uuid primary key default gen_random_uuid(),
+  substrategy_id uuid not null references substrategies(id) on delete cascade,
+  title text not null,
+  description text,
+  priority priority_enum not null,
+  implementation_group_id uuid not null references implementation_groups(id),
+  created_at timestamptz not null default now()
+);
+
+-- 6. SOURCES (Reusable)
+create table sources (id uuid primary key default gen_random_uuid(), name text unique);
+create table guideline_sources (
+  guideline_id uuid not null references guidelines(id) on delete cascade,
+  source_id uuid not null references sources(id) on delete cascade,
+  primary key (guideline_id, source_id)
+);
+
+-- 7. MANY-TO-MANY TAG RELATIONS
+create table guideline_dependencies (
+  guideline_id uuid not null references guidelines(id) on delete cascade,
+  dependent_group_id uuid not null references implementation_groups(id),
+  primary key (guideline_id, dependent_group_id)
+);
+create table guideline_target_groups (
+  guideline_id uuid not null references guidelines(id) on delete cascade,
+  target_group_id uuid not null references target_groups(id),
+  primary key (guideline_id, target_group_id)
+);
+create table guideline_life_cycle_phases (
+  guideline_id uuid not null references guidelines(id) on delete cascade,
+  phase life_cycle_phase_enum not null,
+  primary key (guideline_id, phase)
+);
+create table guideline_hull_types (
+  guideline_id uuid not null references guidelines(id) on delete cascade,
+  hull_type_id uuid not null references hull_types(id),
+  primary key (guideline_id, hull_type_id)
+);
+create table guideline_propulsion_types (
+  guideline_id uuid not null references guidelines(id) on delete cascade,
+  propulsion_type_id uuid not null references propulsion_types(id),
+  primary key (guideline_id, propulsion_type_id)
+);
+create table guideline_yacht_size_classes (
+  guideline_id uuid not null references guidelines(id) on delete cascade,
+  size_class_id uuid not null references yacht_size_classes(id),
+  primary key (guideline_id, size_class_id)
+);
+create table guideline_operational_profiles (
+  guideline_id uuid not null references guidelines(id) on delete cascade,
+  profile_id uuid not null references operational_profiles(id),
+  primary key (guideline_id, profile_id)
+);
+create table guideline_trls (
+  guideline_id uuid not null references guidelines(id) on delete cascade,
+  trl_id uuid not null references technology_readiness_levels(id),
+  primary key (guideline_id, trl_id)
+);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,6 +26,7 @@ import {
   Package,
   Settings,
   LogOut,
+  Leaf,
 } from "lucide-react"
 import FileUploader from "@/components/file-uploader"
 import DocumentProcessor from "@/components/document-processor"
@@ -33,6 +34,7 @@ import ParsingValidation from "@/components/parsing-validation"
 import GWPCalculator from "@/components/gwp-calculator"
 import ResultsDisplay from "@/components/results-display"
 import MaterialsManager from "@/components/materials-manager"
+import GuidelinesList from "@/components/ecodesign/guidelines-list"
 import LoginForm from "@/components/login-form"
 import { authService } from "@/lib/auth"
 import { useAppState } from "@/lib/services/app-state"
@@ -168,6 +170,12 @@ export default function LightshipweightGWPTool() {
       description: "Manage your assessments",
       badge: currentProject ? "Active" : undefined,
     },
+    {
+      id: "ecodesign",
+      label: "EcoDesign",
+      icon: Leaf,
+      description: "Guidelines for sustainable design",
+    },
   ]
 
   // Add Materials DB only for admin
@@ -257,6 +265,7 @@ export default function LightshipweightGWPTool() {
                   {activeView === "dashboard" && "Dashboard"}
                   {activeView === "calculator" && "GWP Calculator"}
                   {activeView === "materials" && "Materials Database"}
+                  {activeView === "ecodesign" && "EcoDesign"}
                   {activeView === "projects" && "My Projects"}
                   {activeView === "create-project" && "Create Project"}
                 </h2>
@@ -264,6 +273,7 @@ export default function LightshipweightGWPTool() {
                   {activeView === "dashboard" && "Overview of your environmental analysis"}
                   {activeView === "calculator" && getCurrentStepInfo().description}
                   {activeView === "materials" && "Manage your materials library"}
+                  {activeView === "ecodesign" && "Explore sustainable guidelines"}
                   {activeView === "projects" && "Manage your projects"}
                   {activeView === "create-project" && "Create a new project"}
                 </p>
@@ -504,6 +514,7 @@ export default function LightshipweightGWPTool() {
           )}
 
           {activeView === "materials" && authService.hasAccess("admin") && <MaterialsManager />}
+          {activeView === "ecodesign" && <GuidelinesList />}
         </main>
       </div>
 

--- a/src/components/ecodesign/guidelines-list.tsx
+++ b/src/components/ecodesign/guidelines-list.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  guidelinesService,
+  LIFE_CYCLE_PHASES,
+  type Guideline,
+  type CreateGuidelineData,
+  type TargetGroup,
+  type ImplementationGroup,
+} from "@/lib/services/guidelines-service";
+import { authService } from "@/lib/auth";
+
+export default function GuidelinesList() {
+  const [guidelines, setGuidelines] = useState<
+    (Guideline & {
+      life_cycle_phases: { phase: string }[];
+      target_groups: { target_group_id: string }[];
+    })[]
+  >([]);
+  const [loading, setLoading] = useState(true);
+  const [targetGroups, setTargetGroups] = useState<TargetGroup[]>([]);
+  const [implementationGroups, setImplementationGroups] = useState<
+    ImplementationGroup[]
+  >([]);
+
+  const [phaseFilter, setPhaseFilter] = useState("");
+  const [targetGroupFilter, setTargetGroupFilter] = useState("");
+
+  const [newGuideline, setNewGuideline] = useState<CreateGuidelineData>({
+    substrategy_id: "",
+    title: "",
+    description: "",
+    priority: "Medium",
+    implementation_group_id: "",
+    target_group_ids: [],
+    life_cycle_phases: [],
+  });
+
+  const isAdmin = authService.isAdmin();
+
+  useEffect(() => {
+    fetchGuidelines();
+    fetchTargetGroups();
+    fetchImplementationGroups();
+  }, []);
+
+  const fetchGuidelines = async () => {
+    try {
+      const data = await guidelinesService.getGuidelines();
+      setGuidelines(data);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchTargetGroups = async () => {
+    try {
+      const data = await guidelinesService.getTargetGroups();
+      setTargetGroups(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const fetchImplementationGroups = async () => {
+    try {
+      const data = await guidelinesService.getImplementationGroups();
+      setImplementationGroups(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleCreate = async () => {
+    if (!newGuideline.title || !newGuideline.substrategy_id) return;
+    try {
+      await guidelinesService.createGuideline(newGuideline);
+      setNewGuideline({
+        substrategy_id: "",
+        title: "",
+        description: "",
+        priority: "Medium",
+        implementation_group_id: "",
+        target_group_ids: [],
+        life_cycle_phases: [],
+      });
+      fetchGuidelines();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const filtered = guidelines.filter((g) => {
+    const matchesPhase = phaseFilter
+      ? g.life_cycle_phases.some((p) => p.phase === phaseFilter)
+      : true;
+    const matchesTarget = targetGroupFilter
+      ? g.target_groups.some((tg) => tg.target_group_id === targetGroupFilter)
+      : true;
+    return matchesPhase && matchesTarget;
+  });
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>EcoDesign Guidelines</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex gap-4">
+            <Select value={phaseFilter} onValueChange={setPhaseFilter}>
+              <SelectTrigger className="w-40">
+                <SelectValue placeholder="Phase" />
+              </SelectTrigger>
+              <SelectContent>
+                {LIFE_CYCLE_PHASES.map((p) => (
+                  <SelectItem key={p} value={p}>
+                    {p}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select
+              value={targetGroupFilter}
+              onValueChange={setTargetGroupFilter}
+            >
+              <SelectTrigger className="w-40">
+                <SelectValue placeholder="Target group" />
+              </SelectTrigger>
+              <SelectContent>
+                {targetGroups.map((tg) => (
+                  <SelectItem key={tg.id} value={tg.id}>
+                    {tg.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          {loading ? (
+            <p>Loading guidelines...</p>
+          ) : (
+            <ul className="space-y-3">
+              {filtered.map((g) => (
+                <li key={g.id} className="border p-3 rounded-md">
+                  <h3 className="font-medium">{g.title}</h3>
+                  {g.description && (
+                    <p className="text-sm text-slate-600">{g.description}</p>
+                  )}
+                </li>
+              ))}
+              {filtered.length === 0 && <p>No guidelines found.</p>}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      {isAdmin && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Add Guideline</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Input
+              placeholder="Substrategy ID"
+              value={newGuideline.substrategy_id}
+              onChange={(e) =>
+                setNewGuideline({
+                  ...newGuideline,
+                  substrategy_id: e.target.value,
+                })
+              }
+            />
+            <Input
+              placeholder="Title"
+              value={newGuideline.title}
+              onChange={(e) =>
+                setNewGuideline({ ...newGuideline, title: e.target.value })
+              }
+            />
+            <Textarea
+              placeholder="Description"
+              value={newGuideline.description}
+              onChange={(e) =>
+                setNewGuideline({
+                  ...newGuideline,
+                  description: e.target.value,
+                })
+              }
+            />
+            <Select
+              value={newGuideline.implementation_group_id}
+              onValueChange={(v) =>
+                setNewGuideline({ ...newGuideline, implementation_group_id: v })
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Implementation group" />
+              </SelectTrigger>
+              <SelectContent>
+                {implementationGroups.map((ig) => (
+                  <SelectItem key={ig.id} value={ig.id}>
+                    {ig.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <div>
+              <p className="text-sm font-medium">Target Groups</p>
+              <div className="flex flex-wrap gap-2 mt-1">
+                {targetGroups.map((tg) => (
+                  <label
+                    key={tg.id}
+                    className="flex items-center gap-1 text-sm"
+                  >
+                    <input
+                      type="checkbox"
+                      className="accent-blue-600"
+                      checked={newGuideline.target_group_ids.includes(tg.id)}
+                      onChange={(e) => {
+                        if (e.target.checked) {
+                          setNewGuideline({
+                            ...newGuideline,
+                            target_group_ids: [
+                              ...newGuideline.target_group_ids,
+                              tg.id,
+                            ],
+                          });
+                        } else {
+                          setNewGuideline({
+                            ...newGuideline,
+                            target_group_ids:
+                              newGuideline.target_group_ids.filter(
+                                (id) => id !== tg.id,
+                              ),
+                          });
+                        }
+                      }}
+                    />
+                    {tg.label}
+                  </label>
+                ))}
+              </div>
+            </div>
+            <div>
+              <p className="text-sm font-medium">Life Cycle Phases</p>
+              <div className="flex flex-wrap gap-2 mt-1">
+                {LIFE_CYCLE_PHASES.map((phase) => (
+                  <label
+                    key={phase}
+                    className="flex items-center gap-1 text-sm"
+                  >
+                    <input
+                      type="checkbox"
+                      className="accent-blue-600"
+                      checked={newGuideline.life_cycle_phases.includes(phase)}
+                      onChange={(e) => {
+                        if (e.target.checked) {
+                          setNewGuideline({
+                            ...newGuideline,
+                            life_cycle_phases: [
+                              ...newGuideline.life_cycle_phases,
+                              phase,
+                            ],
+                          });
+                        } else {
+                          setNewGuideline({
+                            ...newGuideline,
+                            life_cycle_phases:
+                              newGuideline.life_cycle_phases.filter(
+                                (p) => p !== phase,
+                              ),
+                          });
+                        }
+                      }}
+                    />
+                    {phase}
+                  </label>
+                ))}
+              </div>
+            </div>
+            <Button onClick={handleCreate}>Save Guideline</Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {isAdmin && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Manage Lookups</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div>
+              <h4 className="font-medium mb-2">Add Target Group</h4>
+              <Input placeholder="Code" id="tg-code" className="mb-2" />
+              <Input placeholder="Label" id="tg-label" className="mb-2" />
+              <Button
+                onClick={async () => {
+                  const code = (
+                    document.getElementById("tg-code") as HTMLInputElement
+                  ).value;
+                  const label = (
+                    document.getElementById("tg-label") as HTMLInputElement
+                  ).value;
+                  if (code && label) {
+                    await guidelinesService.createTargetGroup({ code, label });
+                    fetchTargetGroups();
+                    (
+                      document.getElementById("tg-code") as HTMLInputElement
+                    ).value = "";
+                    (
+                      document.getElementById("tg-label") as HTMLInputElement
+                    ).value = "";
+                  }
+                }}
+              >
+                Save Target Group
+              </Button>
+            </div>
+            <div>
+              <h4 className="font-medium mb-2">Add Implementation Group</h4>
+              <Input placeholder="Code" id="ig-code" className="mb-2" />
+              <Input placeholder="Label" id="ig-label" className="mb-2" />
+              <Button
+                onClick={async () => {
+                  const code = (
+                    document.getElementById("ig-code") as HTMLInputElement
+                  ).value;
+                  const label = (
+                    document.getElementById("ig-label") as HTMLInputElement
+                  ).value;
+                  if (code && label) {
+                    await guidelinesService.createImplementationGroup({
+                      code,
+                      label,
+                    });
+                    fetchImplementationGroups();
+                    (
+                      document.getElementById("ig-code") as HTMLInputElement
+                    ).value = "";
+                    (
+                      document.getElementById("ig-label") as HTMLInputElement
+                    ).value = "";
+                  }
+                }}
+              >
+                Save Implementation Group
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/lib/services/guidelines-service.ts
+++ b/src/lib/services/guidelines-service.ts
@@ -1,0 +1,170 @@
+import { supabase } from "../supabase";
+
+export interface Guideline {
+  id: string;
+  substrategy_id: string;
+  title: string;
+  description?: string;
+  priority: "Low" | "Medium" | "High";
+  implementation_group_id: string;
+  created_at: string;
+}
+
+export interface CreateGuidelineData {
+  substrategy_id: string;
+  title: string;
+  description?: string;
+  priority: "Low" | "Medium" | "High";
+  implementation_group_id: string;
+  target_group_ids: string[];
+  life_cycle_phases: string[];
+}
+
+export interface TargetGroup {
+  id: string;
+  code: string;
+  label: string;
+}
+
+export interface ImplementationGroup {
+  id: string;
+  code: string;
+  label: string;
+}
+
+export const LIFE_CYCLE_PHASES = [
+  "Upstream",
+  "Design",
+  "Production",
+  "Operation",
+  "Downstream",
+  "End-of-Life",
+] as const;
+
+export class GuidelinesService {
+  async getGuidelines(): Promise<
+    (Guideline & {
+      life_cycle_phases: { phase: string }[];
+      target_groups: { target_group_id: string }[];
+    })[]
+  > {
+    const { data, error } = await supabase
+      .from("lcd_guidelines.guidelines")
+      .select(
+        "*, guideline_life_cycle_phases(phase), guideline_target_groups(target_group_id)",
+      )
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      throw new Error(`Failed to fetch guidelines: ${error.message}`);
+    }
+
+    return data || [];
+  }
+
+  async createGuideline(guideline: CreateGuidelineData): Promise<Guideline> {
+    const { target_group_ids, life_cycle_phases, ...core } = guideline;
+
+    const { data, error } = await supabase
+      .from("lcd_guidelines.guidelines")
+      .insert(core)
+      .select("*")
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to create guideline: ${error.message}`);
+    }
+
+    const inserted = data;
+
+    if (target_group_ids.length) {
+      await supabase
+        .from("lcd_guidelines.guideline_target_groups")
+        .insert(
+          target_group_ids.map((id) => ({
+            guideline_id: inserted.id,
+            target_group_id: id,
+          })),
+        );
+    }
+
+    if (life_cycle_phases.length) {
+      await supabase
+        .from("lcd_guidelines.guideline_life_cycle_phases")
+        .insert(
+          life_cycle_phases.map((phase) => ({
+            guideline_id: inserted.id,
+            phase,
+          })),
+        );
+    }
+
+    return inserted;
+  }
+
+  async getTargetGroups(): Promise<TargetGroup[]> {
+    const { data, error } = await supabase
+      .from("lcd_guidelines.target_groups")
+      .select("*")
+      .order("label", { ascending: true });
+
+    if (error) {
+      throw new Error(`Failed to fetch target groups: ${error.message}`);
+    }
+
+    return data || [];
+  }
+
+  async createTargetGroup(data: {
+    code: string;
+    label: string;
+  }): Promise<TargetGroup> {
+    const { data: res, error } = await supabase
+      .from("lcd_guidelines.target_groups")
+      .insert(data)
+      .select("*")
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to create target group: ${error.message}`);
+    }
+
+    return res;
+  }
+
+  async getImplementationGroups(): Promise<ImplementationGroup[]> {
+    const { data, error } = await supabase
+      .from("lcd_guidelines.implementation_groups")
+      .select("*")
+      .order("label", { ascending: true });
+
+    if (error) {
+      throw new Error(
+        `Failed to fetch implementation groups: ${error.message}`,
+      );
+    }
+
+    return data || [];
+  }
+
+  async createImplementationGroup(data: {
+    code: string;
+    label: string;
+  }): Promise<ImplementationGroup> {
+    const { data: res, error } = await supabase
+      .from("lcd_guidelines.implementation_groups")
+      .insert(data)
+      .select("*")
+      .single();
+
+    if (error) {
+      throw new Error(
+        `Failed to create implementation group: ${error.message}`,
+      );
+    }
+
+    return res;
+  }
+}
+
+export const guidelinesService = new GuidelinesService();


### PR DESCRIPTION
## Summary
- expand EcoDesign guidelines features
- allow admins to manage target and implementation groups
- enable life-cycle phase & target group filters for normal users
- update guidelines service for relations
- document usage in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68542a7af494832ab62aef9e3415f3fc